### PR TITLE
[calendar] add `/innovation/calendar.ics`

### DIFF
--- a/_events/2018-07-12-LDTC.md
+++ b/_events/2018-07-12-LDTC.md
@@ -1,6 +1,8 @@
 ---
 title: Legislative Data and Transparency Conference
 event_date: '2018-07-12'
+hour_begin: 0900
+hour_end: 1600
 ---
 
 ## House Legislative Data and Transparency Conference

--- a/_events/2018-11-01-BDTF.md
+++ b/_events/2018-11-01-BDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Bulk Data Task Force
 event_date: '2018-11-01'
+hour_begin: 1400
+hour_end: 1500
 ---
 
 ## Bulk Data Task Force

--- a/_events/2019-07-09-BDTF.md
+++ b/_events/2019-07-09-BDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Bulk Data Task Force
 event_date: '2019-07-09'
+hour_begin: 1100
+hour_end: 1200
 ---
 
 ## Bulk Data Task Force

--- a/_events/2019-10-17-LDTC.md
+++ b/_events/2019-10-17-LDTC.md
@@ -1,6 +1,8 @@
 ---
 title: Legislative Data and Transparency Conference
 event_date: '2019-10-17'
+hour_begin: 0830
+hour_end: 1630
 ---
 
 ## Legislative Data and Transparency Conference

--- a/_events/2020-09-10-CVPF.md
+++ b/_events/2020-09-10-CVPF.md
@@ -1,6 +1,8 @@
 ---
 title: Congress.gov Virtual Public Forum
 event_date: '2020-09-10'
+hour_begin: 1000
+hour_end: 1300
 ---
 
 ## Congress.gov Virtual Public Forum

--- a/_events/2021-07-14-BDTF.md
+++ b/_events/2021-07-14-BDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Bulk Data Task Force
 event_date: '2021-07-14'
+hour_begin: 1000
+hour_end: 1200
 ---
 
 ## Bulk Data Task Force

--- a/_events/2022-03-10-BDTF.md
+++ b/_events/2022-03-10-BDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Bulk Data Task Force
 event_date: '2022-03-10'
+hour_begin: 1400
+hour_end: 1530
 ---
 
 ## Bulk Data Task Force

--- a/_events/2022-06-21-BDTF.md
+++ b/_events/2022-06-21-BDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Bulk Data Task Force
 event_date: '2022-06-21'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Bulk Data Task Force (Congressional Data Task Force)

--- a/_events/2022-09-21-CVPF.md
+++ b/_events/2022-09-21-CVPF.md
@@ -1,6 +1,8 @@
 ---
 title: Congress.gov Virtual Public Forum
 event_date: '2022-09-21'
+hour_begin: 1330
+hour_end: 1630
 ---
 
 ## Congress.gov Virtual Public Forum

--- a/_events/2022-09-29-CDTF.md
+++ b/_events/2022-09-29-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2022-09-29'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2022-12-13-CDTF.md
+++ b/_events/2022-12-13-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2022-12-13'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2023-03-14-CDTF.md
+++ b/_events/2023-03-14-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2023-03-14'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2023-06-22-CDTF.md
+++ b/_events/2023-06-22-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2023-06-22'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2023-09-13-CPF.md
+++ b/_events/2023-09-13-CPF.md
@@ -1,6 +1,8 @@
 ---
 title: Congress.gov Public Forum
 event_date: '2023-09-13'
+hour_begin: 1300
+hour_end: 1500
 ---
 
 ## Congress.gov Public Forum

--- a/_events/2023-09-14-HACKATHON.md
+++ b/_events/2023-09-14-HACKATHON.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Hackathon 5.0
 event_date: '2023-09-14'
+hour_begin: 1300
+hour_end: 1800
 ---
 
 ## Congressional Hackathon 5.0

--- a/_events/2023-12-19-CDTF.md
+++ b/_events/2023-12-19-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2023-12-19'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2024-03-19-CDTF.md
+++ b/_events/2024-03-19-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2024-03-19'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2024-06-06-CDTF.md
+++ b/_events/2024-06-06-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2024-06-06'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2024-09-18-CPF.md
+++ b/_events/2024-09-18-CPF.md
@@ -1,6 +1,8 @@
 ---
 title: Congress.gov Public Forum
 event_date: '2024-09-18'
+hour_begin: 1300
+hour_end: 1500
 ---
 
 ## Congress.gov Public Forum

--- a/_events/2024-09-19-HACKATHON.md
+++ b/_events/2024-09-19-HACKATHON.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Hackathon 6.0
 event_date: '2024-09-19'
+hour_begin: 1300
+hour_end: 1800
 ---
 
 ## Congressional Hackathon 6.0

--- a/_events/2024-12-12-CDTF.md
+++ b/_events/2024-12-12-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2024-12-12'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2025-03-11-CDTF.md
+++ b/_events/2025-03-11-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2025-03-11'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2025-06-10-CDTF.md
+++ b/_events/2025-06-10-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2025-06-10'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2025-09-17-HACKATHON.md
+++ b/_events/2025-09-17-HACKATHON.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Hackathon 7.0
 event_date: '2025-09-17'
+hour_begin: 1300
+hour_end: 1800
 ---
 
 ## Congressional Hackathon 7.0  

--- a/_events/2025-09-30-CPF.md
+++ b/_events/2025-09-30-CPF.md
@@ -1,6 +1,8 @@
 ---
 title: Congress.gov Public Forum
 event_date: '2025-09-30'
+hour_begin: 1300
+hour_end: 1500
 ---
 
 ## Congress.gov Public Forum

--- a/_events/2025-12-09-CDTF.md
+++ b/_events/2025-12-09-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2025-12-09'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2026-03-26-CDTF.md
+++ b/_events/2026-03-26-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2026-03-26'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2026-06-11-CDTF.md
+++ b/_events/2026-06-11-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2026-06-11'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_events/2026-12-03-CDTF.md
+++ b/_events/2026-12-03-CDTF.md
@@ -1,6 +1,8 @@
 ---
 title: Congressional Data Task Force  
 event_date: '2026-12-03'
+hour_begin: 1400
+hour_end: 1600
 ---
 
 ## Congressional Data Task Force  

--- a/_pages/calendar.html
+++ b/_pages/calendar.html
@@ -1,0 +1,40 @@
+---
+title: Calendar
+permalink: /calendar.ics
+layout: none
+---
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:https://usgpo.github.io/innovation
+METHOD:PUBLISH
+
+BEGIN:VTIMEZONE
+TZID:America/New_York
+BEGIN:STANDARD
+DTSTART:20071104T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20070311T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+END:DAYLIGHT
+END:VTIMEZONE
+
+{% for event in site.events %}BEGIN:VEVENT
+UID:{{ event.event_date | date: "%Y/%m/%d" }}@usgpo.github.io/innovation
+SUMMARY:{{ event.title }}
+CLASS:PUBLIC
+DTSTART;TZID=America/New_York:{{ event.event_date | date: "%Y%m%d" }}T{{ event.hour_begin }}
+DTEND;TZID=America/New_York:{{ event.event_date | date: "%Y%m%d" }}T{{ event.hour_end }}
+DTSTAMP;TZID=America/New_York:{{ event.event_date | date: "%Y%m%d" }}T{{ event.hour_begin }}
+URL:{{ site.baseurl }}{{ event.url }}
+END:VEVENT
+{% endfor %}
+END:VCALENDAR


### PR DESCRIPTION
## sources:

- loosely inspired by [jekyll.ics](https://gist.github.com/woodworker/6725728)
- [timezone](https://stackoverflow.com/questions/35645402/how-to-specify-timezone-in-ics-file-which-will-work-efficiently-with-google-outl)
- [timezone summary](https://search.brave.com/search?q=ics+timezone+america%2Fnew_york&summary=1&conversation=08f0b397ec0279612fa2bb7fa10a3ecd0952)
- [vEVENT spec](https://icalendar.org/iCalendar-RFC-5545/3-6-1-event-component.html)