### PR TITLE
Update theme from 1.? -> 4.0.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ plugins:
 - jekyll-remote-theme 
 
 
-remote_theme: 18f/uswds-jekyll@38f6d3ceac7a04fa6d53ebcbaace81b909ea5801
+remote_theme: 18f/uswds-jekyll@2b2dcdf0aca440e8f7e417930783489fb46b6d3f  # v4.0.0
 
 defaults:
   -

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,4 +1,7 @@
+type: medium
 contact: 
-   address: | 
-     <!---Site maintained by the United States Government Publishing Office on behalf of the Legislative branch Bulk Data Task Force and civil society organizations.--->
-     [Github Repository](https://github.com/usgpo/innovation/)
+  contact_links:
+    - text: GitHub Repository
+      href: https://github.com/usgpo/innovation/
+      external: true
+      type: github


### PR DESCRIPTION
4.0.0 seems to be as far as we can go without making more significant changes (the latest is 5.5.0 and it's no longer being developed).